### PR TITLE
Ajust function name

### DIFF
--- a/api.py
+++ b/api.py
@@ -46,7 +46,7 @@ def api_cert_info_hostname(hostname):
 
 
 @app.route('/api/v1/cert/info/commonName', methods=['GET'])
-def api_cert_info_commonName():
+def api_cert_info_common_name():
     """ Return a JSON with the certificate commonName info """
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
         cert_list_common_name = []
@@ -61,7 +61,7 @@ def api_cert_info_commonName():
 
 
 @app.route('/api/v1/cert/info/subjectAltName', methods=['GET'])
-def api_cert_info_subjectAltName():
+def api_cert_info_subject_alt_name():
     """ Return a JSON with the certificate subjectAltName info """
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
         cert_list_subject_alt_name = []


### PR DESCRIPTION
- api.py:49:0: C0103: Function name "api_cert_info_commonName" doesn't conform to snake_case naming style (invalid-name)
- api.py:64:0: C0103: Function name "api_cert_info_subjectAltName" doesn't conform to snake_case naming style (invalid-name)